### PR TITLE
Fix bugs with rating of image

### DIFF
--- a/src/rating/repository.py
+++ b/src/rating/repository.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.database.sql.alchemy_models import User, Rating, Image
+from src.image.repository import ImageQuery
 
 
 class RatingQuery:
@@ -57,4 +58,6 @@ class RatingQuery:
             return None
         await db.delete(rating)
         await db.commit()
+        image = await ImageQuery.read(rating.image_id, db)
+        await RatingQuery._update_average_rating(image, db)
         return rating


### PR DESCRIPTION
The Delete method now has the corrected code — previously, when removing an image, the rating was not recalculated.
The rating is now being adjusted correctly.
If the photo was not evaluated, the rating would be 0.